### PR TITLE
ui: render content only, no rerender component

### DIFF
--- a/internal/duck_dom/component.go
+++ b/internal/duck_dom/component.go
@@ -41,16 +41,9 @@ func CreateComponent(buffer string, styles Styles) *Component {
 
 func (self *Component) Render(builder *strings.Builder) {
 	self.rearrange_component()
-	if self.Active {
-		builder.WriteString(INVERT_STYLES)
-	} else {
-		builder.WriteString(RESET_STYLES)
-	}
-	self.Styles.Compile(builder)
 	self.calculate_dimensions()
 	self.assert_component_dimensions()
-	self.render_background(builder)
-	self.render_buffer(builder)
+	self.render_content(builder)
 
 	if self.Styles.Border != NoBorder {
 		render_border(builder, self.Position, self.Active, &self.Styles)
@@ -218,6 +211,17 @@ func (self *Component) render_buffer(content_builder *strings.Builder) {
 		content_builder.WriteString(content)
 		lines_used += 1
 	}
+}
+
+func (self *Component) render_content(content_builder *strings.Builder) {
+	if self.Active {
+		content_builder.WriteString(INVERT_STYLES)
+	} else {
+		content_builder.WriteString(RESET_STYLES)
+	}
+	self.Styles.Compile(content_builder)
+	self.render_background(content_builder)
+	self.render_buffer(content_builder)
 }
 
 func (self *Component) assert_component_dimensions() {

--- a/internal/duck_dom/dd.go
+++ b/internal/duck_dom/dd.go
@@ -281,13 +281,13 @@ func (*InsertMode) HandleKeypress(screen *Screen, keys []byte) {
 		active_component := screen.get_active_component()
 		if len(active_component.Buffer) != 0 {
 			active_component.Buffer = active_component.Buffer[:len(active_component.Buffer)-1]
-			active_component.Render(&screen.RenderQueue)
+			active_component.render_content(&screen.RenderQueue)
 		}
 	default:
 		active_component := screen.get_active_component()
 		active_component.Buffer += string(keys[0])
 		active_component.buffer_vertical_scroll_from += 1
-		active_component.Render(&screen.RenderQueue)
+		active_component.render_content(&screen.RenderQueue)
 	}
 }
 


### PR DESCRIPTION
### TL;DR
Refactored component rendering logic to improve code organization and reduce redundancy.

### What changed?
- Extracted component styling and content rendering into a new `render_content` method
- Updated `Render` method to use the new `render_content` function
- Modified `InsertMode.HandleKeypress` to call `render_content` directly when updating component buffers
